### PR TITLE
Add site libs support, add more preinstalled packages, fix sudo check

### DIFF
--- a/.Renviron
+++ b/.Renviron
@@ -1,0 +1,2 @@
+# add your GITHUB PAT and uncomment this line to avoid rate limits
+# GITHUB_PAT=

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get install -y \
 RUN echo "rstudio ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
 
 # setup base renv for lessons that want to use it
-RUN R -e 'install.packages(c("renv", "remotes", "httpuv", "httr"), repos = c(CRAN = "https://cloud.r-project.org"))'
+RUN R -e 'install.packages(c("renv", "remotes", "httpuv", "httr", "gh"), repos = c(CRAN = "https://cloud.r-project.org"))'
 
 ARG SANDPAPER_VER
 ARG VARNISH_VER
@@ -53,6 +53,9 @@ ENV VARNISH_VER=${VARNISH_VER}
 ENV PEGBOARD_VER=${PEGBOARD_VER}
 
 WORKDIR /home/rstudio
+
+COPY .Renviron /home/rstudio/.Renviron
+RUN chown -R rstudio:rstudio /home/rstudio/.Renviron
 
 COPY scripts/* /home/rstudio/.workbench/
 RUN chmod +x /home/rstudio/.workbench/*

--- a/scripts/deps.R
+++ b/scripts/deps.R
@@ -126,5 +126,5 @@ update(pkgs, upgrade = "always")
 install_latest_release("varnish")
 install_latest_release("pegboard")
 
-# install sandpaper from site libs PR branch
-remotes::install_github("froggleston/sandpaper", ref = "frog-site-libs-1")
+# install sandpaper from main (0.17.2.9000) until next release (0.17.2)
+remotes::install_github("carpentries/sandpaper", ref = "main")

--- a/scripts/deps.R
+++ b/scripts/deps.R
@@ -45,6 +45,75 @@ cat("Repositories Used")
 print(getOption("repos"))
 cat("::endgroup::\n")
 
+# install common dependencies for lessons that use Rmarkdown
+common_deps <- c(
+    "base64enc",
+    "bit",
+    "bit64",
+    "bslib",
+    "cachem",
+    "cli",
+    "cpp11",
+    "crayon",
+    "curl",
+    "devtools",
+    "digest",
+    "dplyr",
+    "evaluate",
+    "fastmap",
+    "fontawesome",
+    "fs",
+    "ggplot2",
+    "glue",
+    "highr",
+    "htmltools",
+    "inline",
+    "jquerylib",
+    "jsonlite",
+    "knitr",
+    "lifecycle",
+    "lubridate",
+    "magrittr",
+    "memoise",
+    "mime",
+    "pillar",
+    "pkgconfig",
+    "purrr",
+    "R6",
+    "ragg",
+    "rappdirs",
+    "readr",
+    "reprex",
+    "rlang",
+    "rmarkdown",
+    "sass",
+    "selectr",
+    "stringi",
+    "stringr",
+    "svglite",
+    "sys",
+    "systemfonts",
+    "textshaping",
+    "tibble",
+    "tidyr",
+    "tidyverse",
+    "tinytex",
+    "tzdb",
+    "uuid",
+    "vctrs",
+    "vroom",
+    "whisker",
+    "withr",
+    "xfun",
+    "xml2",
+    "yaml"
+)
+
+# Install common deps
+for (pkg in common_deps) {
+    install.packages(pkg)
+}
+
 sand_deps <- remotes::package_deps("sandpaper")
 varn_deps <- remotes::package_deps("varnish")
 sess_deps <- remotes::package_deps("sessioninfo")
@@ -53,6 +122,9 @@ pkgs      <- rbind(sand_deps, varn_deps, sess_deps, with_deps)
 print(pkgs)
 update(pkgs, upgrade = "always")
 
-install_latest_release("sandpaper")
+# install_latest_release("sandpaper")
 install_latest_release("varnish")
 install_latest_release("pegboard")
+
+# install sandpaper from site libs PR branch
+remotes::install_github("froggleston/sandpaper", ref = "frog-site-libs-1")

--- a/scripts/fortify_renv_cache.R
+++ b/scripts/fortify_renv_cache.R
@@ -43,11 +43,11 @@ if (file.exists(file.path(wd, 'renv'))) {
     }
     req("renv")
     Sys.setenv("RENV_PROFILE" = "lesson-requirements")
-    tryCatch(sandpaper::manage_deps(path = wd, quiet = FALSE),
+    tryCatch(sandpaper::manage_deps(path = wd, quiet = FALSE, use_site_libs = TRUE),
         error = function(e) {
             iss <- "https://github.com/rstudio/renv/issues/1184"
             cli::cli_alert_danger("run failed... attempting to re-run (see {.url {iss}} for details.")
-            sandpaper::manage_deps(path = wd, quiet = FALSE)
+            sandpaper::manage_deps(path = wd, quiet = FALSE, use_site_libs = TRUE)
         }
     )
     cat("::endgroup::\n")

--- a/scripts/setup_lesson_deps.R
+++ b/scripts/setup_lesson_deps.R
@@ -65,14 +65,16 @@ if (on_linux && has_lock) {
     writeLines(readLines("DESCRIPTION"))
 
     # hack to get around sudo being hardcoded into vise apt-get update
+    sudo <- FALSE
     if (on_linux) {
         if (is_root_euid()) {
             system("apt-get update")
         }
         else {
             system("sudo apt-get update")
+            sudo <- TRUE
         }
     }
 
-    vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE, sudo = FALSE)
+    vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE, sudo = sudo)
 }


### PR DESCRIPTION
This PR adds in a number of new features:

- Adds preinstalled R packages that are common to many lessons
- Add R_SITE_LIBS support: as packages are installed within the container in a controlled environment separate from the host OS, we are safe to use the site-wide R library paths to act as a repo for packages. As such, hydration will link to these pre-installed container R packages before restoring renv, greatly speeding up builds.
- Fixes the sudo check in `setup_lesson_deps.R`, meaning the scripts will work locally and on GitHub with no extra configuration.

NOTE: Currently this requires the site-libs feature in sandpaper main. This will need to be implemented when sandpaper is updated to use all the new workflows.