### PR TITLE
Add rsync for dovetail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN apt-get install -y \
     nano \
     gh \
     cmake \
+    rsync \
     && apt-get clean all \
     && apt-get purge \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
The {dovetail} package requires rsync, so adding to system dependencies.