### PR TITLE
Add minimal image builds

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -128,6 +128,65 @@ jobs:
           path: ${{ runner.temp }}/workbench-amd64.tar
           retention-days: 1
 
+  build-amd64-minimal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Image (AMD64)
+        id: build_amd64_minimal
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          file: Dockerfile.minimal
+          build-args: |
+            SANDPAPER_REF=${{ env.SANDPAPER_REF }}
+            VARNISH_REF=${{ env.VARNISH_REF }}
+            PEGBOARD_REF=${{ env.PEGBOARD_REF }}
+            NO_LATEST=${{ env.NO_LATEST }}
+            R_VERSION=${{ env.R_VERSION }}
+          outputs: |
+            type=image,"name=${{ env.DOCKERHUB_REPO }}",name-canonical=true
+            type=docker,dest=${{ runner.temp }}/workbench-amd64-minimal.tar
+          push: false
+          tags: ${{ env.DOCKERHUB_REPO }}
+          cache-to: ${{ (((github.ref_name == 'main' && github.event_name == 'push') || github.event_name == 'release' || github.event_name == 'workflow_dispatch') && 'type=gha,mode=max,scope=amd64') || '' }}
+          cache-from: type=gha,scope=amd64
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build_amd64_minimal.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          ls -lAh "${{ runner.temp }}/digests"
+          echo "IMAGE_DIGEST_AMD64_MINIMAL=${digest#sha256:}" >> $GITHUB_ENV
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-amd64-minimal
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload Tarball as Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: docker-amd64-minimal
+          path: ${{ runner.temp }}/workbench-amd64-minimal.tar
+          retention-days: 1
+
   build-arm64:
     if: |
       (
@@ -280,6 +339,81 @@ jobs:
           ${{ env.DOCKERHUB_REPO }} \
           /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
+  push-test-minimal:
+    if: |
+      github.repository == 'carpentries/workbench-docker' &&
+      (
+        github.event_name == 'release' ||
+        (
+          github.event_name == 'push' &&
+          (
+            startsWith(github.ref_name, 'release-')
+          )
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          (
+            startsWith(github.ref_name, 'dev-') ||
+            inputs.run-tests
+          )
+        )
+      )
+    needs:
+      - build-amd64-minimal
+    permissions:
+      checks: write
+      contents: write
+      pages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        lesson: [carpentries/instructor-training, swcarpentry/shell-novice]
+        include:
+          - lesson: carpentries/instructor-training
+            lesson-name: Instructor Training
+          - lesson: swcarpentry/shell-novice
+            lesson-name: Shell Novice
+
+    name: ${{ matrix.lesson-name }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash # forces 'Git for Windows' on Windows
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout Lesson
+        if: "${{ matrix.lesson != '' }}"
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ matrix.lesson }}
+          path: lesson_tmp
+
+      - name: Set Permissions for Lesson Dir
+        run: |
+          chmod -R 777 ${{ github.workspace }}/lesson_tmp
+          ls -lAh ${{ github.workspace }}/lesson_tmp
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-amd64-minimal
+          path: ${{ runner.temp }}
+
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/workbench-amd64-minimal.tar
+          docker image ls -a
+
+      - name: Run Tests on ${{ matrix.lesson }}
+        run: |
+          docker run --rm \
+          -e GITHUB_PAT=$GITHUB_PAT \
+          -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
+          -w /home/rstudio/lesson \
+          ${{ env.DOCKERHUB_REPO }} \
+          /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
+
   publish-test:
     if: github.event_name == 'release' && github.repository == 'carpentries/workbench-docker'
     needs:
@@ -404,6 +538,72 @@ jobs:
             ${{ env.DOCKERHUB_REPO }}:latest-amd64
             ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-amd64
             ${{ env.GHCR_REPO }}:latest-amd64
+          cache-from: type=gha,scope=amd64
+
+  publish-amd64-minimal:
+    if: github.repository == 'carpentries/workbench-docker'
+    needs:
+      - build-amd64-minimal
+      - push-test-minimal
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Push version minimal AMD64 image only
+        if: ${{ inputs.no-latest }}
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          file: Dockerfile.minimal
+          build-args: |
+            SANDPAPER_REF=${{ env.SANDPAPER_REF }}
+            VARNISH_REF=${{ env.VARNISH_REF }}
+            PEGBOARD_REF=${{ env.PEGBOARD_REF }}
+            NO_LATEST=${{ env.NO_LATEST }}
+            R_VERSION=${{ env.R_VERSION }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
+            ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
+          cache-from: type=gha,scope=amd64
+
+      - name: Push minimal AMD64 image
+        if: ${{ github.event_name == 'release' && !inputs.no-latest }}
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          file: Dockerfile.minimal
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
+            ${{ env.DOCKERHUB_REPO }}:latest-amd64-minimal
+            ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
+            ${{ env.GHCR_REPO }}:latest-amd64-minimal
           cache-from: type=gha,scope=amd64
 
   publish-arm64:
@@ -536,6 +736,60 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}
 
+  merge-amd64-minimal-only:
+    runs-on: ubuntu-latest
+    if: inputs.no-latest && !inputs.build-arm && github.repository == 'carpentries/workbench-docker'
+    needs:
+      - publish-amd64-minimal
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+            ${{ env.GHCR_REPO }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Create AMD version manifest and push
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-minimal \
+            -t ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-minimal \
+            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-minimal
+
   merge-amd64-arm64-only:
     runs-on: ubuntu-latest
     if: inputs.no-latest && inputs.build-arm && github.repository == 'carpentries/workbench-docker'
@@ -660,6 +914,68 @@ jobs:
             ${{ env.GHCR_REPO }}:latest-amd64 \
             ${{ env.GHCR_REPO }}:latest-arm64
 
+  merge-minimal:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && !inputs.no-latest && github.repository == 'carpentries/workbench-docker'
+    needs:
+      - publish-amd64-minimal
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+            ${{ env.GHCR_REPO }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=semver,pattern=latest-minimal,enable={{is_default_branch}}
+            type=sha
+
+      - name: Create version manifest and push
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.DOCKERHUB_REPO }}:v${{ steps.meta.outputs.version }}-minimal \
+            ${{ env.DOCKERHUB_REPO }}:v${{ steps.meta.outputs.version }}-amd64-minimal
+
+          docker buildx imagetools create \
+            -t ${{ env.DOCKERHUB_REPO }}:latest-minimal \
+            ${{ env.DOCKERHUB_REPO }}:latest-amd64-minimal
+
+          docker buildx imagetools create \
+            -t ${{ env.GHCR_REPO }}:v${{ steps.meta.outputs.version }}-minimal \
+            ${{ env.GHCR_REPO }}:v${{ steps.meta.outputs.version }}-amd64-minimal
+
+          docker buildx imagetools create \
+            -t ${{ env.GHCR_REPO }}:latest-minimal \
+            ${{ env.GHCR_REPO }}:latest-amd64-minimal
+
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:latest
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:latest-minimal


### PR DESCRIPTION
Add support for minimal builds, which contain R and the minimal set of packages required for non-RMarkdown builds. This should speed up builds for lessons without renv in future.
