### PR TITLE
Release 0.2.7

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -73,7 +73,7 @@ jobs:
   build-amd64:
     runs-on: ubuntu-latest
     outputs:
-      image-version: ${{ steps.meta.outputs.version }}
+      image-version: "${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -133,7 +133,7 @@ jobs:
   build-amd64-minimal:
     runs-on: ubuntu-latest
     outputs:
-      image-version: ${{ steps.meta.outputs.version }}
+      image-version: "${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -144,10 +144,8 @@ jobs:
         with:
           images: |
             ${{ env.DOCKERHUB_REPO }}
-          tags: |
-            type=match,pattern=release-(\d+\.\d+\.\d+),group=1,suffix=-minimal
-            type=match,pattern=(dev-\d+\.\d+\.\d+),group=1,suffix=-minimal
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }},suffix=-minimal
+          flavor: |
+            suffix=-minimal
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -214,7 +212,7 @@ jobs:
       )
     runs-on: ubuntu-24.04-arm
     outputs:
-      image-version: ${{ steps.meta.outputs.version }}
+      image-version: "${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -346,7 +344,7 @@ jobs:
           -e GITHUB_PAT=$GITHUB_PAT \
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
-          ${{ env.DOCKERHUB_REPO }}:${{ needs.build-amd64.outputs.image-version }} \
+          ${{ needs.build-amd64.outputs.image-version }} \
           /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   push-test-minimal:
@@ -421,7 +419,7 @@ jobs:
           -e GITHUB_PAT=$GITHUB_PAT \
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
-          ${{ env.DOCKERHUB_REPO }}:${{ needs.build-amd64-minimal.outputs.image-version }} \
+          ${{ needs.build-amd64-minimal.outputs.image-version }} \
           /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   publish-test:
@@ -483,7 +481,7 @@ jobs:
           -e GITHUB_PAT=$GITHUB_PAT \
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
-          ${{ env.DOCKERHUB_REPO }}:${{ needs.build-amd64.outputs.image-version }} \
+          ${{ needs.build-amd64.outputs.image-version }} \
           /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   publish-amd64:
@@ -576,6 +574,8 @@ jobs:
         with:
           images: |
             ${{ env.DOCKERHUB_REPO }}
+          flavor: |
+            suffix=-minimal
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -788,17 +788,19 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+          flavor: |
+            suffix=-minimal
 
       - name: Create AMD version manifest and push
         run: |
           docker buildx imagetools create \
-            -t ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-minimal \
-            -t ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-minimal \
-            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-minimal-amd64
+            -t ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }} \
+            -t ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }} \
+            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-amd64
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-minimal
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}
 
   merge-amd64-arm64-only:
     runs-on: ubuntu-latest
@@ -965,22 +967,24 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=semver,pattern=latest-minimal,enable={{is_default_branch}}
+            type=semver,pattern=latest,enable={{is_default_branch}}
             type=sha
+          flavor: |
+            suffix=-minimal
 
       - name: Create version manifest and push
         run: |
           docker buildx imagetools create \
-            -t ${{ env.DOCKERHUB_REPO }}:v${{ steps.meta.outputs.version }}-minimal \
-            ${{ env.DOCKERHUB_REPO }}:v${{ steps.meta.outputs.version }}-minimal-amd64
+            -t ${{ env.DOCKERHUB_REPO }}:v${{ steps.meta.outputs.version }} \
+            ${{ env.DOCKERHUB_REPO }}:v${{ steps.meta.outputs.version }}-amd64
 
           docker buildx imagetools create \
             -t ${{ env.DOCKERHUB_REPO }}:latest-minimal \
             ${{ env.DOCKERHUB_REPO }}:latest-minimal-amd64
 
           docker buildx imagetools create \
-            -t ${{ env.GHCR_REPO }}:v${{ steps.meta.outputs.version }}-minimal \
-            ${{ env.GHCR_REPO }}:v${{ steps.meta.outputs.version }}-minimal-amd64
+            -t ${{ env.GHCR_REPO }}:v${{ steps.meta.outputs.version }} \
+            ${{ env.GHCR_REPO }}:v${{ steps.meta.outputs.version }}-amd64
 
           docker buildx imagetools create \
             -t ${{ env.GHCR_REPO }}:latest-minimal \

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -350,7 +350,7 @@ jobs:
           -e GITHUB_PAT=$GITHUB_PAT \
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
-          ${{ needs.build-amd64.outputs.image-version }} \
+          ${{ env.DOCKERHUB_REPO }} \
           "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   push-test-minimal:
@@ -488,7 +488,7 @@ jobs:
           -e GITHUB_PAT=$GITHUB_PAT \
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
-          ${{ needs.build-amd64.outputs.image-version }} \
+          ${{ env.DOCKERHUB_REPO }} \
           "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   publish-amd64:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: false
         type: boolean
+      build-minimal:
+        description: 'Build minimal image?'
+        required: false
+        default: false
+        type: boolean
       run-tests:
         description: 'Run Tests'
         required: false
@@ -131,6 +136,7 @@ jobs:
           retention-days: 1
 
   build-amd64-minimal:
+    if: ${{ inputs.build-minimal }}
     runs-on: ubuntu-latest
     outputs:
       image-version: "${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}"
@@ -345,10 +351,11 @@ jobs:
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
           ${{ needs.build-amd64.outputs.image-version }} \
-          /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
+          "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   push-test-minimal:
     if: |
+      inputs.build-minimal &&
       github.repository == 'carpentries/workbench-docker' &&
       (
         github.event_name == 'release' ||
@@ -420,7 +427,7 @@ jobs:
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
           ${{ needs.build-amd64-minimal.outputs.image-version }} \
-          /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
+          "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   publish-test:
     if: github.event_name == 'release' && github.repository == 'carpentries/workbench-docker'
@@ -482,7 +489,7 @@ jobs:
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
           ${{ needs.build-amd64.outputs.image-version }} \
-          /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
+          "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   publish-amd64:
     if: github.repository == 'carpentries/workbench-docker'
@@ -549,7 +556,9 @@ jobs:
           cache-from: type=gha,scope=amd64
 
   publish-amd64-minimal:
-    if: github.repository == 'carpentries/workbench-docker'
+    if: |
+      inputs.build-minimal &&
+      github.repository == 'carpentries/workbench-docker'
     needs:
       - build-amd64-minimal
       - push-test-minimal
@@ -748,7 +757,7 @@ jobs:
 
   merge-amd64-minimal-only:
     runs-on: ubuntu-latest
-    if: inputs.no-latest && !inputs.build-arm && github.repository == 'carpentries/workbench-docker'
+    if: inputs.build-minimal && inputs.no-latest && !inputs.build-arm && github.repository == 'carpentries/workbench-docker'
     needs:
       - publish-amd64-minimal
     steps:
@@ -928,7 +937,7 @@ jobs:
 
   merge-minimal:
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && !inputs.no-latest && github.repository == 'carpentries/workbench-docker'
+    if: inputs.build-minimal && github.event_name == 'release' && !inputs.no-latest && github.repository == 'carpentries/workbench-docker'
     needs:
       - publish-amd64-minimal
     steps:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -136,7 +136,7 @@ jobs:
           retention-days: 1
 
   build-amd64-minimal:
-    if: ${{ inputs.build-minimal }}
+    if: inputs.build-minimal
     runs-on: ubuntu-latest
     outputs:
       image-version: "${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}"

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -72,6 +72,8 @@ jobs:
 
   build-amd64:
     runs-on: ubuntu-latest
+    outputs:
+      image-version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -130,6 +132,8 @@ jobs:
 
   build-amd64-minimal:
     runs-on: ubuntu-latest
+    outputs:
+      image-version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -140,6 +144,10 @@ jobs:
         with:
           images: |
             ${{ env.DOCKERHUB_REPO }}
+          tags: |
+            type=match,pattern=release-(\d+\.\d+\.\d+),group=1,suffix=-minimal
+            type=match,pattern=(dev-\d+\.\d+\.\d+),group=1,suffix=-minimal
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }},suffix=-minimal
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -160,7 +168,7 @@ jobs:
             type=image,"name=${{ env.DOCKERHUB_REPO }}",name-canonical=true
             type=docker,dest=${{ runner.temp }}/workbench-amd64-minimal.tar
           push: false
-          tags: ${{ env.DOCKERHUB_REPO }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-to: ${{ (((github.ref_name == 'main' && github.event_name == 'push') || github.event_name == 'release' || github.event_name == 'workflow_dispatch') && 'type=gha,mode=max,scope=amd64') || '' }}
           cache-from: type=gha,scope=amd64
 
@@ -205,6 +213,8 @@ jobs:
         )
       )
     runs-on: ubuntu-24.04-arm
+    outputs:
+      image-version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -336,7 +346,7 @@ jobs:
           -e GITHUB_PAT=$GITHUB_PAT \
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
-          ${{ env.DOCKERHUB_REPO }} \
+          ${{ env.DOCKERHUB_REPO }}:${{ needs.build-amd64.outputs.image-version }} \
           /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   push-test-minimal:
@@ -411,7 +421,7 @@ jobs:
           -e GITHUB_PAT=$GITHUB_PAT \
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
-          ${{ env.DOCKERHUB_REPO }} \
+          ${{ env.DOCKERHUB_REPO }}:${{ needs.build-amd64-minimal.outputs.image-version }} \
           /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   publish-test:
@@ -473,7 +483,7 @@ jobs:
           -e GITHUB_PAT=$GITHUB_PAT \
           -v ${{ github.workspace }}/lesson_tmp:/home/rstudio/lesson \
           -w /home/rstudio/lesson \
-          ${{ env.DOCKERHUB_REPO }} \
+          ${{ env.DOCKERHUB_REPO }}:${{ needs.build-amd64.outputs.image-version }} \
           /bin/bash -c "/home/rstudio/.workbench/ci_lesson_pre_prep.sh"
 
   publish-amd64:
@@ -586,8 +596,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
-            ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
+            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-amd64
+            ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-amd64
           cache-from: type=gha,scope=amd64
 
       - name: Push minimal AMD64 image
@@ -600,10 +610,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
-            ${{ env.DOCKERHUB_REPO }}:latest-amd64-minimal
-            ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
-            ${{ env.GHCR_REPO }}:latest-amd64-minimal
+            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-amd64
+            ${{ env.DOCKERHUB_REPO }}:latest-minimal-amd64
+            ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-amd64
+            ${{ env.GHCR_REPO }}:latest-minimal-amd64
           cache-from: type=gha,scope=amd64
 
   publish-arm64:
@@ -784,7 +794,7 @@ jobs:
           docker buildx imagetools create \
             -t ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-minimal \
             -t ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}-minimal \
-            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-amd64-minimal
+            ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}-minimal-amd64
 
       - name: Inspect image
         run: |
@@ -962,19 +972,19 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t ${{ env.DOCKERHUB_REPO }}:v${{ steps.meta.outputs.version }}-minimal \
-            ${{ env.DOCKERHUB_REPO }}:v${{ steps.meta.outputs.version }}-amd64-minimal
+            ${{ env.DOCKERHUB_REPO }}:v${{ steps.meta.outputs.version }}-minimal-amd64
 
           docker buildx imagetools create \
             -t ${{ env.DOCKERHUB_REPO }}:latest-minimal \
-            ${{ env.DOCKERHUB_REPO }}:latest-amd64-minimal
+            ${{ env.DOCKERHUB_REPO }}:latest-minimal-amd64
 
           docker buildx imagetools create \
             -t ${{ env.GHCR_REPO }}:v${{ steps.meta.outputs.version }}-minimal \
-            ${{ env.GHCR_REPO }}:v${{ steps.meta.outputs.version }}-amd64-minimal
+            ${{ env.GHCR_REPO }}:v${{ steps.meta.outputs.version }}-minimal-amd64
 
           docker buildx imagetools create \
             -t ${{ env.GHCR_REPO }}:latest-minimal \
-            ${{ env.GHCR_REPO }}:latest-amd64-minimal
+            ${{ env.GHCR_REPO }}:latest-minimal-amd64
 
       - name: Inspect image
         run: |

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN <<SYSDEPS
     installr -c
-    installr -a "bash pandoc-cli aws-cli github-cli cmake rsync curl curl-dev linux-headers libxml2-dev fontconfig-dev harfbuzz-dev fribidi-dev freetype-dev tiff-dev jpeg-dev libgit2-dev libxslt-dev zlib-dev icu-dev openssl-dev libuv-dev libjpeg-turbo-dev libpng-dev nano cairo cairo-dev"
+    installr -a "bash coreutils pandoc-cli aws-cli github-cli cmake rsync curl curl-dev linux-headers libxml2-dev fontconfig-dev harfbuzz-dev fribidi-dev freetype-dev tiff-dev jpeg-dev libgit2-dev libxslt-dev zlib-dev icu-dev openssl-dev libuv-dev libjpeg-turbo-dev libpng-dev nano cairo cairo-dev"
 SYSDEPS
 
 # add rstudio user, home directory, and add to sudo group

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ We currently provide two pre-built images:
 - linux/amd64
 - linux/arm64
 
+A minimal image based on alpine is currently in development:
+- linux/amd64-minimal
+
 ## Current Known Issues
 
 - Building images locally from scratch are likely not to work on Mac M* (M1, M2, etc), but should be fine on Mac Intel

--- a/scripts/ci_run_tests.R
+++ b/scripts/ci_run_tests.R
@@ -1,3 +1,5 @@
+readRenviron("/home/rstudio/.Renviron")
+
 source("/home/rstudio/.workbench/setup_lesson_deps.R")
 source("/home/rstudio/.workbench/fortify_renv_cache.R")
 

--- a/scripts/deps.R
+++ b/scripts/deps.R
@@ -1,6 +1,20 @@
 library(remotes)
 library(httr)
 
+detect_linux_distro <- function() {
+    if (Sys.info()[["sysname"]] == "Linux") {
+        os_release <- readLines("/etc/os-release")
+        distro <- sub("ID=(.*)$", "\\1", os_release[grepl("^ID=", os_release)])
+        release <- sub("VERSION_ID=(.*)$", "\\1", os_release[grepl("^VERSION_ID=", os_release)])
+        codename <- ""
+        if (distro == "ubuntu") {
+            codename <- sub("UBUNTU_CODENAME=(.*)$", "\\1", os_release[grepl("^UBUNTU_CODENAME=", os_release)])
+        }
+        return(list(distro = distro, version = release, codename = codename))
+    }
+    return(NULL)
+}
+
 install_latest_release <- function(pkg) {
   api_url <- paste0("https://api.github.com/repos/carpentries/", pkg, "/releases/latest")
   resp <- httr::GET(api_url)
@@ -24,11 +38,22 @@ options(HTTPUserAgent = sprintf("R/%s R (%s)", RV, OS))
 cat("::group::Register Repositories\n")
 on_linux <- Sys.info()[["sysname"]] == "Linux"
 if (on_linux) {
+    release <- detect_linux_distro()
     if (Sys.getenv("RSPM") == "") {
-        release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
-        Sys.setenv("RSPM" =
-            paste0("https://packagemanager.posit.co/all/__linux__/", release, "/latest")
-        )
+        if (!is.null(release)) {
+            distro <- release$distro
+            version <- release$version
+            if (distro == "ubuntu") {
+                codename <- release$codename
+                Sys.setenv("RSPM" =
+                    paste0("https://packagemanager.posit.co/all/__linux__/", codename, "/latest")
+                )
+            } else if (distro == "alpine") {
+                Sys.setenv("RSPM" =
+                    paste0("https://packagemanager.posit.co/cran/latest")
+                )
+            }
+        }
     }
 }
 

--- a/scripts/fortify_renv_cache.R
+++ b/scripts/fortify_renv_cache.R
@@ -1,11 +1,37 @@
 cat("::group::Register Repositories\n")
 on_linux <- Sys.info()[["sysname"]] == "Linux"
+
+detect_linux_distro <- function() {
+    if (Sys.info()[["sysname"]] == "Linux") {
+        os_release <- readLines("/etc/os-release")
+        distro <- sub("ID=(.*)$", "\\1", os_release[grepl("^ID=", os_release)])
+        release <- sub("VERSION_ID=(.*)$", "\\1", os_release[grepl("^VERSION_ID=", os_release)])
+        codename <- ""
+        if (distro == "ubuntu") {
+            codename <- sub("UBUNTU_CODENAME=(.*)$", "\\1", os_release[grepl("^UBUNTU_CODENAME=", os_release)])
+        }
+        return(list(distro = distro, version = release, codename = codename))
+    }
+    return(NULL)
+}
+
 if (on_linux) {
+    release <- detect_linux_distro()
     if (Sys.getenv("RSPM") == "") {
-        release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
-        Sys.setenv("RSPM" =
-            paste0("https://packagemanager.posit.co/all/__linux__/", release, "/latest")
-        )
+        if (!is.null(release)) {
+            distro <- release$distro
+            version <- release$version
+            if (distro == "ubuntu") {
+                codename <- release$codename
+                Sys.setenv("RSPM" =
+                    paste0("https://packagemanager.posit.co/all/__linux__/", codename, "/latest")
+                )
+            } else {
+                Sys.setenv("RSPM" =
+                    paste0("https://packagemanager.posit.co/cran/latest")
+                )
+            }
+        }
     }
 }
 repos <- list(

--- a/scripts/setup_lesson_deps.R
+++ b/scripts/setup_lesson_deps.R
@@ -1,80 +1,114 @@
-cat("::group::Register Repositories\n")
-on_linux <- Sys.info()[["sysname"]] == "Linux"
-
-is_root_euid <- function() {
-  result <- system("id -u", intern = TRUE)
-  return(as.numeric(result) == 0)
-}
-
-if (on_linux) {
-    if (Sys.getenv("RSPM") == "") {
-        release <- system("lsb_release -c | awk '{print $2}'", intern = TRUE)
-        Sys.setenv("RSPM" =
-            paste0("https://packagemanager.posit.co/all/__linux__/", release, "/latest")
-        )
-    }
-}
-repos <- list(
-    RSPM        = Sys.getenv("RSPM"),
-    carpentries = "https://carpentries.r-universe.dev/",
-    ropensci    = "https://ropensci.r-universe.dev/",
-    archive     = "https://carpentries.github.io/drat/",
-    CRAN        = "https://cran.rstudio.com"
-)
-
-options(pak.no_extra_messages = TRUE, repos = repos)
-
-cat("Repositories Used")
-print(getOption("repos"))
-cat("::endgroup::\n")
-
-# Set up system dependencies
-req <- function(pkg, ...) {
-    if (!requireNamespace(pkg, quietly = TRUE)) {
-        install.packages(pkg, ...)
-    }
-}
-
 wd <- "."
 has_lock <- file.exists(file.path(wd, 'renv'))
-if (on_linux && has_lock) {
-    req("renv")
-    req("remotes")
-    rmts <- asNamespace("remotes")
-    # extract the function
-    sov <- rmts$supported_os_versions
-    # if 24.04 is not present, we need to modify the function
-    if (!grepl("24.04", body(sov)[2])) {
-        unlockBinding("supported_os_versions", rmts)
-        # modify the list in the body to include 22.04
-        vers <- eval(parse(text = as.character(body(sov)[2])))
-        vers$ubuntu <- c(vers$ubuntu, "24.04")
-        # replace the body
-        body(sov)[2] <- list(str2lang(paste(capture.output(dput(vers)), collapse = "")))
-        # replace the function in the namespace
-        rmts$supported_os_versions <- sov
-    }
-    req("desc")
-    remotes::install_github("carpentries/vise@main")
-    if (file.exists("DESCRIPTION")) {
-        file.rename("DESCRIPTION", "DESCRIPTION.bak")
-    }
-    Sys.setenv("RENV_PROFILE" = "lesson-requirements")
-    Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
-    vise::lock2desc(renv::paths$lockfile(), desc = "DESCRIPTION")
-    writeLines(readLines("DESCRIPTION"))
 
-    # hack to get around sudo being hardcoded into vise apt-get update
-    sudo <- FALSE
+if (has_lock) {
+    cat("::group::Register Repositories\n")
+    on_linux <- Sys.info()[["sysname"]] == "Linux"
+
+    detect_linux_distro <- function() {
+        if (Sys.info()[["sysname"]] == "Linux") {
+            os_release <- readLines("/etc/os-release")
+            distro <- sub("ID=(.*)$", "\\1", os_release[grepl("^ID=", os_release)])
+            release <- sub("VERSION_ID=(.*)$", "\\1", os_release[grepl("^VERSION_ID=", os_release)])
+            codename <- ""
+            if (distro == "ubuntu") {
+                codename <- sub("UBUNTU_CODENAME=(.*)$", "\\1", os_release[grepl("^UBUNTU_CODENAME=", os_release)])
+            }
+            return(list(distro = distro, version = release, codename = codename))
+        }
+        return(NULL)
+    }
+
+    is_root_euid <- function() {
+        result <- system("id -u", intern = TRUE)
+        return(as.numeric(result) == 0)
+    }
+
     if (on_linux) {
-        if (is_root_euid()) {
-            system("apt-get update")
+        release <- detect_linux_distro()
+        if (Sys.getenv("RSPM") == "") {
+            if (!is.null(release)) {
+                distro <- release$distro
+                version <- release$version
+                if (distro == "ubuntu") {
+                    codename <- release$codename
+                    Sys.setenv("RSPM" =
+                        paste0("https://packagemanager.posit.co/all/__linux__/", codename, "/latest")
+                    )
+                } else if (distro == "alpine") {
+                    Sys.setenv("RSPM" =
+                        paste0("https://packagemanager.posit.co/cran/latest")
+                    )
+                }
+            }
         }
-        else {
-            system("sudo apt-get update")
-            sudo <- TRUE
+    }
+    repos <- list(
+        RSPM        = Sys.getenv("RSPM"),
+        carpentries = "https://carpentries.r-universe.dev/",
+        ropensci    = "https://ropensci.r-universe.dev/",
+        archive     = "https://carpentries.github.io/drat/",
+        CRAN        = "https://cran.rstudio.com"
+    )
+
+    options(pak.no_extra_messages = TRUE, repos = repos)
+
+    cat("Repositories Used")
+    print(getOption("repos"))
+    cat("::endgroup::\n")
+
+    # Set up system dependencies
+    req <- function(pkg, ...) {
+        if (!requireNamespace(pkg, quietly = TRUE)) {
+            install.packages(pkg, ...)
         }
     }
 
-    vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE, sudo = sudo)
+    if (on_linux) {
+        req("renv")
+        req("remotes")
+        rmts <- asNamespace("remotes")
+        # extract the function
+        sov <- rmts$supported_os_versions
+        # if 24.04 is not present, we need to modify the function
+        if (release$distro == "ubuntu") {
+            if (!grepl("24.04", body(sov)[2])) {
+                unlockBinding("supported_os_versions", rmts)
+                # modify the list in the body to include 22.04
+                vers <- eval(parse(text = as.character(body(sov)[2])))
+                vers$ubuntu <- c(vers$ubuntu, "24.04")
+                # replace the body
+                body(sov)[2] <- list(str2lang(paste(capture.output(dput(vers)), collapse = "")))
+                # replace the function in the namespace
+                rmts$supported_os_versions <- sov
+            }
+        }
+        req("desc")
+        remotes::install_github("carpentries/vise@main")
+        if (file.exists("DESCRIPTION")) {
+            file.rename("DESCRIPTION", "DESCRIPTION.bak")
+        }
+        Sys.setenv("RENV_PROFILE" = "lesson-requirements")
+        Sys.setenv("RSPM_ROOT" = "https://packagemanager.posit.co")
+        vise::lock2desc(renv::paths$lockfile(), desc = "DESCRIPTION")
+        writeLines(readLines("DESCRIPTION"))
+
+        # hack to get around sudo being hardcoded into vise apt-get update
+        sudo <- FALSE
+        if (on_linux) {
+            if (release$distro == "ubuntu") {
+                if (is_root_euid()) {
+                    system("apt-get update")
+                }
+                else {
+                    system("sudo apt-get update")
+                    sudo <- TRUE
+                }
+            } else if (release$distro == "alpine") {
+                system("apk update")
+            }
+        }
+
+        vise::ci_sysreqs(renv::paths$lockfile(), execute = TRUE, sudo = sudo)
+    }
 }


### PR DESCRIPTION
Adds:

- [sandpaper 0.20.2](https://github.com/carpentries/sandpaper/releases/tag/0.20.2)
- [varnish 1.1.1](https://github.com/carpentries/varnish/releases/tag/1.1.1)

This PR also includes preliminary support for a minimal Alpine based image, but this is not complete (image builds work, lesson builds do not).